### PR TITLE
The signature'size  must be 128

### DIFF
--- a/src/main/java/com/firestack/laksaj/crypto/Signature.java
+++ b/src/main/java/com/firestack/laksaj/crypto/Signature.java
@@ -2,6 +2,7 @@ package com.firestack.laksaj.crypto;
 
 import lombok.Data;
 import lombok.Builder;
+import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 
@@ -13,9 +14,16 @@ public class Signature {
 
     @Override
     public String toString() {
-        String rs = r.toString(16);
-        String ss = s.toString(16);
-        return rs + ss;
+        String rHex = Hex.toHexString(r.toByteArray());
+        while (rHex.length() < 64) {
+            rHex = "0" + rHex;
+        }
+
+        String sHex = Hex.toHexString(s.toByteArray());
+        while (sHex.length() < 64) {
+            sHex = "0" + sHex;
+        }
+        return rHex + sHex;
     }
 
     public boolean isNil() {


### PR DESCRIPTION
After sign ,if the  signature hex  string  size   is not 128 , it will be rejected by the full  node .